### PR TITLE
Add a default filter to filter_features if none is supplied

### DIFF
--- a/app/service/spotify_service.py
+++ b/app/service/spotify_service.py
@@ -38,12 +38,14 @@ def fetch_features(track_ids, features_to_consider):
 
 
 def filter_features(features_by_id, features_to_consider):
+    if not bool(features_to_consider):
+        features_to_consider = ['acousticness', 'danceability', 'energy', 'instrumentalness', 'speechiness']
+
     for track_features in features_by_id.items():
         # Filter out the unwanted features
         # If features_to_consider is empty, all numerical features will be used (except time_signature and duration)
         filtered_features = {feature: value for (feature, value) in track_features[1].items() if
-                             isinstance(value, numbers.Number) and
-                             (feature in features_to_consider or not bool(features_to_consider))}
+                             isinstance(value, numbers.Number) and feature in features_to_consider}
 
         # Neither duration_ms nor time_signature will be considered
         if 'time_signature' in filtered_features:

--- a/tests/test_spotify_service.py
+++ b/tests/test_spotify_service.py
@@ -59,11 +59,7 @@ class TestSpotifyService(TestCase):
         ids = {'06AKEBrKUckW0KREUWRnvT'}
         features_to_consider = {}
         features = fetch_features(ids, features_to_consider)
-        expected_features = {
-            'key', 'mode', 'acousticness', 'danceability', 'energy',
-            'instrumentalness', 'liveness', 'loudness', 'speechiness',
-            'valence', 'tempo'
-        }
+        expected_features = {'acousticness', 'danceability', 'energy', 'instrumentalness', 'speechiness'}
         self.assertEqual(features['06AKEBrKUckW0KREUWRnvT'].keys(), expected_features)
 
     # Test that all features are scaled between 0-1
@@ -117,11 +113,7 @@ class TestSpotifyService(TestCase):
                                        'duration_ms': 255349, 'time_signature': 4}
         }
         features_to_consider = {}
-        expected_features = {
-            'key', 'mode', 'acousticness', 'danceability', 'energy',
-            'instrumentalness', 'liveness', 'loudness', 'speechiness',
-            'valence', 'tempo'
-        }
+        expected_features = {'acousticness', 'danceability', 'energy', 'instrumentalness', 'speechiness'}
         features = filter_features(features_by_id, features_to_consider)
         self.assertEqual(features['06AKEBrKUckW0KREUWRnvT'].keys(), expected_features)
 


### PR DESCRIPTION
If the function is called with an empty list of features to consider, the following features will be chosen by default: 
`acousticness, danceability, energy, instrumentalness, speechiness`