### PR TITLE
Fetch album cover

### DIFF
--- a/app/service/song_list_service.py
+++ b/app/service/song_list_service.py
@@ -13,16 +13,29 @@ def get_json_track_list_by_list_id(list_id):
     # Get a list of tracks
     track_list = get_tracks_by_list_id(list_id)
 
+    # Remove unnecessary tag
+    track_list = [track["track"] for track in track_list]
+
     # Extract the ids of the tracks
-    track_ids = [track['track']['id'] for track in track_list]
+    track_ids = [track['id'] for track in track_list]
 
     # Create a cluster from the tracks
     cluster = get_cluster_by_track_ids(track_ids)
 
+    # Extract cover art
+    track_list = extract_cover_art(track_list)
+
     # Append the cluster_id to the track_list
     for track in track_list:
         # Add the cluster_id (as a normal int, as opposed to int32)
-        track['track']['cluster_id'] = int(cluster[track['track']['id']])
+        track['cluster_id'] = int(cluster[track['id']])
 
     # Convert the cluster into json format
     return json.dumps(track_list, indent=4)
+
+
+def extract_cover_art(track_info):
+    for track_features in track_info:
+        track_features["image_url"] = track_features["album"]["images"][2]["url"]
+        track_features.pop("album")
+    return track_info

--- a/app/service/spotify_service.py
+++ b/app/service/spotify_service.py
@@ -14,7 +14,8 @@ def get_tracks_by_list_id(playlist_uri):
     return spotify.playlist_tracks(playlist_uri, fields='items.track.id, items.track.name, '
                                                         'items.track.preview_url, '
                                                         'items.track.artists.name,'
-                                                        'items.track.external_urls.spotify')['items']
+                                                        'items.track.external_urls.spotify,'
+                                                        'items.track.album.images')['items']
 
 
 def fetch_features(track_ids, features_to_consider):


### PR DESCRIPTION
This introduces the ability to fetch the album covers for the tracks. Specifically, the smallest of the 3 available covers is chosen, and is made available to the endpoint under `image_url`. Also one unnecessary "track" tag was removed from the json so to make the data easier to handle in the frontend.

Resolves #33  